### PR TITLE
domain.xsd

### DIFF
--- a/proposals/domain.xsd
+++ b/proposals/domain.xsd
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://homegatewayinitiative.org/xml/dal/2.0" 
+	   xmlns="http://homegatewayinitiative.org/xml/dal/2.0" 
+	   xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	  
+ elementFormDefault="qualified">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+  <xs:group name="Imports">
+    <xs:sequence>
+      <xs:element minOccurs="0" ref="Imports"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="Imports">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Domain"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Domain">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="Imports"/>
+        <xs:element minOccurs="0" name="Modules">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="ModuleClass"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" ref="RootDevices"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:base"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ModuleClass" type="ModuleDef"/>
+  <xs:element name="RootDevices">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="RootDevice"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RootDevice">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="DeviceInfo"/>
+        <xs:group ref="Doc"/>
+        <xs:element minOccurs="0" ref="Modules"/>
+        <xs:element minOccurs="0" ref="Devices"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:Name"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Devices">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Device"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Device" type="DeviceDef"/>
+  <xs:complexType name="DeviceDef">
+    <xs:sequence>
+      <xs:element ref="DeviceInfo"/>
+      <xs:group ref="Doc"/>
+      <xs:element minOccurs="0" ref="Modules"/>
+    </xs:sequence>
+    <xs:attribute name="id" use="required" type="xs:Name"/>
+  </xs:complexType>
+  <xs:element name="DeviceInfo">
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Name"/>
+        <xs:element ref="Vendor"/>
+        <xs:element minOccurs="0" ref="FirmwareVersion"/>
+        <xs:element minOccurs="0" ref="SerialNumber"/>
+        <xs:element minOccurs="0" ref="VendorURL"/>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Name" type="xs:string"/>
+  <xs:element name="Vendor" type="xs:string"/>
+  <xs:element name="FirmwareVersion" type="xs:string"/>
+  <xs:element name="SerialNumber" type="xs:string"/>
+  <xs:element name="VendorURL" type="xs:anyURI"/>
+  <xs:simpleType name="DataType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="integer"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="byte"/>
+      <xs:enumeration value="float"/>
+      <xs:enumeration value="array"/>
+      <xs:enumeration value="enum"/>
+      <xs:enumeration value="date"/>
+      <xs:enumeration value="time"/>
+      <xs:enumeration value="datetime"/>
+      <xs:enumeration value="blob"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="DocText">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="em"/>
+        <xs:element ref="b"/>
+        <xs:element ref="tt"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="em" type="xs:string"/>
+  <xs:element name="b" type="xs:string"/>
+  <xs:element name="tt" type="xs:string"/>
+  <xs:group name="Doc">
+    <xs:sequence>
+      <xs:element minOccurs="0" ref="Doc"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="Doc">
+    <xs:complexType mixed="true">
+      <xs:choice>
+        <xs:group ref="DocText"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="p"/>
+          <xs:element ref="img"/>
+        </xs:choice>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:group ref="DocText"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="caption"/>
+      </xs:sequence>
+      <xs:attribute name="src" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="caption" type="xs:string"/>
+  <xs:complexType name="ModuleDef">
+  	<xs:sequence>
+  		<xs:element minOccurs="0" ref="extends" />
+  		<xs:group ref="Doc" />
+  		<xs:element minOccurs="0" ref="Actions" />
+  		<xs:element minOccurs="0" ref="Data" />
+  		<xs:element minOccurs="0" ref="Events" />
+  		<xs:element name="ModuleRef" type="ModuleRef" minOccurs="0"
+  			maxOccurs="unbounded">
+  		</xs:element>
+  	</xs:sequence>
+  	<xs:attribute name="name" use="required" />
+  </xs:complexType>
+  <xs:complexType name="ModuleRef">
+      <xs:attribute name="name"/>
+      <xs:attribute name="domain" use="required" type="xs:IDREF"/>
+      <xs:attribute name="class" use="required"/>
+  </xs:complexType>
+  <xs:element name="extends">
+    <xs:complexType>
+      <xs:attribute name="domain" use="required" type="xs:IDREF"/>
+      <xs:attribute name="class" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Modules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Module"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Module" type="ModuleDef"/>
+  <xs:element name="Actions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Action"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Action">
+    <xs:complexType>
+    	<xs:sequence>
+    		<xs:group ref="Doc" />
+    		<xs:element name="ModArg" type="ModuleRef" minOccurs="0"
+  				maxOccurs="unbounded"/>
+		<xs:element minOccurs="0" maxOccurs="unbounded" ref="Arg"/>
+    	</xs:sequence>
+    	<xs:attribute name="name" use="required" />
+    	<xs:attribute name="type" type="xs:string" />
+    	<xs:attribute name="rt" type="xs:string"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Arg">
+    <xs:complexType>
+      <xs:group ref="Doc"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="type" use="required" type="DataType"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Data">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="DataPoint"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DataPoint">
+    <xs:complexType>
+      <xs:group ref="Doc"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="type" use="required" type="DataType"/>
+      <xs:attribute name="writable" type="xs:boolean"/>
+      <xs:attribute name="readable" type="xs:boolean"/>
+      <xs:attribute name="eventable" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Events">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="Event"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Event">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Data"/>
+        <xs:group ref="Doc"/>
+      </xs:sequence>
+      <xs:attribute name="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
added a “ModuleRef” field to ModuleDef in order to allow a Module to represent more complex data structures
added a “ModArg” field to an action description, of type ModuleRef in order to allow an Action to take complex data structures in input and return them in output
